### PR TITLE
fix: Salary not calculated

### DIFF
--- a/src/main/java/com/softeng/dingtalk/service/AuditService.java
+++ b/src/main/java/com/softeng/dingtalk/service/AuditService.java
@@ -97,6 +97,7 @@ public class AuditService {
                 .orElse(new DcSummary(uid, yearmonth));
         dcSummary.updateWeek(week, dcRecordRepository.getUserWeekTotalDc(uid, yearmonth, week));
         dcSummaryRepository.save(dcSummary);
+        performanceService.computeSalary(uid, yearmonth);
     }
 
 


### PR DESCRIPTION
重构的bug，刷新绩效的时候薪资没有被计算